### PR TITLE
Make a small spelling fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Function api
 
-Mod that allows minectaft functions to be run on certain events of the game. Add an event tag to your function for it to run.
+Mod that allows Minecraft functions to be run on certain events of the game. Add an event tag to your function for it to run.
 
 More information on the wiki page.https://github.com/CottonMC/FunctionAPI/wiki
 


### PR DESCRIPTION
`minectaft` -> `Minecraft`